### PR TITLE
Fix for log format causing Jinja2 template error

### DIFF
--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.repo_name }}/__init__.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.repo_name }}/__init__.py
@@ -27,5 +27,5 @@ CONFIG_TYPE = Optional[Dict[str, Any]]
 ARGS: Optional[argparse.Namespace] = None
 CONFIG: CONFIG_TYPE = None
 
-LOG_FMT = '%(levelname)s: %(name)s [%(process)d] {%(filename)s@L%(lineno)d}: %(message)s'
+{% raw %}LOG_FMT = '%(levelname)s: %(name)s [%(process)d] {%(filename)s@L%(lineno)d}: %(message)s'{% endraw %}
 LOG_LVL = logging.INFO


### PR DESCRIPTION
Using the latest version of cookiecutter-lux-python, I was getting the following error when trying to create new projects:

```
jinja2.exceptions.TemplateSyntaxError: tag name expected
  File "./{{ cookiecutter.repo_name }}/__init__.py", line 30
    LOG_FMT = '%(levelname)s: %(name)s [%(process)d] {%(filename)s@L%(lineno)d}: %(message)s'
```

The {% } in this line was causing errors with Jinja2. Adding {% raw %} tags fixes this.